### PR TITLE
Allow different localization strategies

### DIFF
--- a/wolf/task.py
+++ b/wolf/task.py
@@ -320,7 +320,6 @@ class Task:
 				# initialize orchestrator and localizer
 				self.orch = canine.Orchestrator(self.conf)
 				self.orch.backend = self.backend
-				print("TASK", self.conf['name'], "Creating localizer")
 				self.localizer = canine.orchestrator.LOCALIZERS[self.conf['localization'].get('strategy', 'NFS')](self.orch.backend, **self.conf['localization'])
 				stack.enter_context(self.localizer)
 


### PR DESCRIPTION
This PR abstracts away the dependency on the NFS localizer by allowing the user to specify a specific localization strategy to the workflow controller. It additionally skips delocalization between tasks, instead using the new [`build_manifest()`] (https://github.com/broadinstitute/canine/pull/37) method on localizers to get a list of output files that can be passed on to dependent tasks.

Lastly, this allows the user to specify workflow-level outputs which get delocalized after the workflow has completed running.

Workflow-level outputs are specified in the return value of `workflow()`. Tasks which have at least one output exposed as a workflow-level output will be fully delocalized.

Blocked by broadinstitute/canine#37